### PR TITLE
Update cmake version of cmake_minimum_required() from 2.8.3 to 3.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.0.2)
 project(ypspur_ros)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
for #74 

I made this correction by visiting http://wiki.ros.org/noetic/Migration.