### PR TITLE
Update ypspur version

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,5 +25,5 @@
   <depend>std_msgs</depend>
   <depend>tf</depend>
   <depend>trajectory_msgs</depend>
-  <depend version_gte="1.17.0">ypspur</depend>
+  <depend version_gte="1.20.0">ypspur</depend>
 </package>


### PR DESCRIPTION
```ypspur``` [added parameter in version 1.20.0](https://github.com/openspur/yp-spur/commit/cdfc9c1b6b8d5b392a7c24f69aa2816eade8ff15), thus the ypspur_ros should use that version to avoid header version mismatch.