### PR TITLE
Migrate to tf2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,9 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
   sensor_msgs
   std_msgs
-  tf
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
   trajectory_msgs
 )
 
@@ -36,28 +38,20 @@ catkin_package(CATKIN_DEPENDS
   nav_msgs
   sensor_msgs
   std_msgs
-  tf
+  tf2
+  tf2_geometry_msgs
+  tf2_ros
   trajectory_msgs
 )
 find_package(Boost REQUIRED COMPONENTS chrono thread atomic REQUIRED)
 
-find_package(ypspur 1.17.0 REQUIRED)
+find_package(ypspur 1.20.0 REQUIRED)
 
 ###########
 ## Build ##
 ###########
 
-include(CheckCXXCompilerFlag)
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-if(COMPILER_SUPPORTS_CXX11)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-elseif(COMPILER_SUPPORTS_CXX0X)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
-else()
-  message(FATAL_ERROR "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. ")
-endif()
-
+set(CMAKE_CXX_STANDARD 14)
 
 include_directories(
   include

--- a/package.xml
+++ b/package.xml
@@ -23,7 +23,9 @@
   <depend>nav_msgs</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
-  <depend>tf</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>tf2_ros</depend>
   <depend>trajectory_msgs</depend>
   <depend version_gte="1.20.0">ypspur</depend>
 </package>

--- a/src/joint_tf_publisher.cpp
+++ b/src/joint_tf_publisher.cpp
@@ -50,7 +50,7 @@ private:
   ros::NodeHandle pnh_;
   std::map<std::string, ros::Subscriber> subs_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
-  tf2::Vector3 z_axis_;
+  const tf2::Vector3 z_axis_;
 
   void cbJoint(const sensor_msgs::JointState::ConstPtr& msg)
   {

--- a/src/joint_tf_publisher.cpp
+++ b/src/joint_tf_publisher.cpp
@@ -50,6 +50,7 @@ private:
   ros::NodeHandle pnh_;
   std::map<std::string, ros::Subscriber> subs_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
+  tf2::Vector3 z_axis_;
 
   void cbJoint(const sensor_msgs::JointState::ConstPtr& msg)
   {
@@ -60,9 +61,7 @@ private:
       trans.header.frame_id = msg->name[i] + "_in";
       trans.child_frame_id = msg->name[i] + "_out";
 
-      tf2::Quaternion quat_tf;
-      quat_tf.setRPY(0, 0, msg->position[i]);
-      trans.transform.rotation = tf2::toMsg(quat_tf);
+      trans.transform.rotation = tf2::toMsg(tf2::Quaternion(z_axis_, msg->position[i]));
       tf_broadcaster_.sendTransform(trans);
     }
   }
@@ -71,6 +70,7 @@ public:
   JointTfPublisherNode()
     : nh_()
     , pnh_("~")
+    , z_axis_(0, 0, 1)
   {
     subs_["joint"] = compat::subscribe(
         nh_, "joint_states",

--- a/src/joint_tf_publisher.cpp
+++ b/src/joint_tf_publisher.cpp
@@ -32,7 +32,8 @@
 #include <geometry_msgs/TransformStamped.h>
 #include <sensor_msgs/JointState.h>
 
-#include <tf/transform_broadcaster.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/transform_broadcaster.h>
 
 #include <signal.h>
 #include <sys/types.h>
@@ -48,7 +49,7 @@ private:
   ros::NodeHandle nh_;
   ros::NodeHandle pnh_;
   std::map<std::string, ros::Subscriber> subs_;
-  tf::TransformBroadcaster tf_broadcaster_;
+  tf2_ros::TransformBroadcaster tf_broadcaster_;
 
   void cbJoint(const sensor_msgs::JointState::ConstPtr& msg)
   {
@@ -58,7 +59,10 @@ private:
       trans.header = msg->header;
       trans.header.frame_id = msg->name[i] + "_in";
       trans.child_frame_id = msg->name[i] + "_out";
-      trans.transform.rotation = tf::createQuaternionMsgFromYaw(msg->position[i]);
+
+      tf2::Quaternion quat_tf;
+      quat_tf.setRPY(0, 0, msg->position[i]);
+      trans.transform.rotation = tf2::toMsg(quat_tf);
       tf_broadcaster_.sendTransform(trans);
     }
   }

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -424,10 +424,10 @@ public:
   YpspurRosNode()
     : nh_()
     , pnh_("~")
+    , tf_listener_(tf_buffer_)
     , device_error_state_(0)
     , device_error_state_prev_(0)
     , device_error_state_time_(0)
-    , tf_listener_(tf_buffer_)
   {
     compat::checkCompatMode();
 

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -88,6 +88,7 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
+  tf2::Vector3 z_axis_;
 
   std::string port_;
   std::string param_file_;
@@ -425,6 +426,7 @@ public:
     : nh_()
     , pnh_("~")
     , tf_listener_(tf_buffer_)
+    , z_axis_(0, 0, 1)
     , device_error_state_(0)
     , device_error_state_prev_(0)
     , device_error_state_time_(0)
@@ -781,9 +783,7 @@ public:
     odom.pose.pose.position.x = 0;
     odom.pose.pose.position.y = 0;
     odom.pose.pose.position.z = 0;
-    tf2::Quaternion quat_tf;
-    quat_tf.setRPY(0, 0, 0);
-    odom.pose.pose.orientation = tf2::toMsg(quat_tf);
+    odom.pose.pose.orientation = tf2::toMsg(tf2::Quaternion(z_axis_, 0));
     odom.twist.twist.linear.x = 0;
     odom.twist.twist.linear.y = 0;
     odom.twist.twist.angular.z = 0;
@@ -856,9 +856,7 @@ public:
         odom.pose.pose.position.x = x;
         odom.pose.pose.position.y = y;
         odom.pose.pose.position.z = 0;
-        tf2::Quaternion quat_tf;
-        quat_tf.setRPY(0, 0, yaw);
-        odom.pose.pose.orientation = tf2::toMsg(quat_tf);
+        odom.pose.pose.orientation = tf2::toMsg(tf2::Quaternion(z_axis_, yaw));
         odom.twist.twist.linear.x = v;
         odom.twist.twist.linear.y = 0;
         odom.twist.twist.angular.z = w;
@@ -1014,11 +1012,9 @@ public:
         }
         pubs_["joint"].publish(joint);
 
-        tf2::Quaternion quat_tf;
         for (unsigned int i = 0; i < joints_.size(); i++)
         {
-          quat_tf.setRPY(0, 0, joint.position[i]);
-          joint_trans[i].transform.rotation = tf2::toMsg(quat_tf);
+          joint_trans[i].transform.rotation = tf2::toMsg(tf2::Quaternion(z_axis_, joint.position[i]));
           joint_trans[i].header.stamp = ros::Time(t) + ros::Duration(tf_time_offset_);
           tf_broadcaster_.sendTransform(joint_trans[i]);
         }

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -88,7 +88,7 @@ private:
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
   tf2_ros::TransformBroadcaster tf_broadcaster_;
-  tf2::Vector3 z_axis_;
+  const tf2::Vector3 z_axis_;
 
   std::string port_;
   std::string param_file_;


### PR DESCRIPTION
This PR replaces calls to `tf` functions with their `tf2` equivalent.