### PR TITLE
Add an option to avoid publishing duplicated odometry

### DIFF
--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -169,9 +169,9 @@ private:
 
   int control_mode_;
 
-  bool avoid_publshing_duplicated_odom_;
+  bool avoid_publishing_duplicated_odom_;
   bool publish_odom_tf_;
-  ros::Time prevous_odom_stamp_;
+  ros::Time previous_odom_stamp_;
 
   void cbControlMode(const ypspur_ros::ControlMode::ConstPtr& msg)
   {
@@ -434,7 +434,7 @@ public:
     , device_error_state_(0)
     , device_error_state_prev_(0)
     , device_error_state_time_(0)
-    , avoid_publshing_duplicated_odom_(false)
+    , avoid_publishing_duplicated_odom_(false)
     , publish_odom_tf_(true)
   {
     compat::checkCompatMode();
@@ -554,7 +554,7 @@ public:
           nh_, "cmd_vel",
           pnh_, "cmd_vel", 1, &YpspurRosNode::cbCmdVel, this);
 
-      pnh_.param("avoid_publshing_duplicated_odom", avoid_publshing_duplicated_odom_, false);
+      pnh_.param("avoid_publishing_duplicated_odom", avoid_publishing_duplicated_odom_, false);
       pnh_.param("publish_odom_tf", publish_odom_tf_, true);
     }
     else if (mode_name.compare("none") == 0)
@@ -862,7 +862,7 @@ public:
         }
 
         const ros::Time current_stamp(t);
-        if (current_stamp > prevous_odom_stamp_)
+        if (!avoid_publishing_duplicated_odom_ || (current_stamp > previous_odom_stamp_))
         {
           odom.header.stamp = current_stamp;
           odom.pose.pose.position.x = x;
@@ -884,7 +884,7 @@ public:
             tf_broadcaster_.sendTransform(odom_trans);
           }
         }
-        prevous_odom_stamp_ = current_stamp;
+        previous_odom_stamp_ = current_stamp;
 
         if (!simulate_control_)
         {

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -434,7 +434,7 @@ public:
     , device_error_state_(0)
     , device_error_state_prev_(0)
     , device_error_state_time_(0)
-    , avoid_publishing_duplicated_odom_(false)
+    , avoid_publishing_duplicated_odom_(true)
     , publish_odom_tf_(true)
   {
     compat::checkCompatMode();
@@ -554,7 +554,7 @@ public:
           nh_, "cmd_vel",
           pnh_, "cmd_vel", 1, &YpspurRosNode::cbCmdVel, this);
 
-      pnh_.param("avoid_publishing_duplicated_odom", avoid_publishing_duplicated_odom_, false);
+      pnh_.param("avoid_publishing_duplicated_odom", avoid_publishing_duplicated_odom_, true);
       pnh_.param("publish_odom_tf", publish_odom_tf_, true);
     }
     else if (mode_name.compare("none") == 0)

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -634,10 +634,11 @@ public:
       {
         std::vector<std::string> args =
             {
-                ypspur_bin_,
-                "-d", port_,
-                "--admask", ad_mask,
-                "--msq-key", std::to_string(key_)};
+              ypspur_bin_,
+              "-d", port_,
+              "--admask", ad_mask,
+              "--msq-key", std::to_string(key_)
+            };
         if (digital_input_enable_)
           args.push_back(std::string("--enable-get-digital-io"));
         if (simulate_)
@@ -705,7 +706,8 @@ public:
       }
       double ret;
       boost::atomic<bool> done(false);
-      auto get_vel_thread = [&ret, &done] {
+      auto get_vel_thread = [&ret, &done]
+      {
         double test_v, test_w;
         ret = YP::YPSpur_get_vel(&test_v, &test_w);
         done = true;
@@ -1087,7 +1089,8 @@ public:
 
               auto vf = [](const double& st, const double& en,
                            const double& acc, const double& err, const double& t,
-                           const int& sig, const int& sol, double& ret) {
+                           const int& sig, const int& sol, double& ret)
+              {
                 double sq;
                 sq = -4.0 * st * st +
                      8.0 * st * en -

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -634,11 +634,10 @@ public:
       {
         std::vector<std::string> args =
             {
-              ypspur_bin_,
-              "-d", port_,
-              "--admask", ad_mask,
-              "--msq-key", std::to_string(key_)
-            };
+                ypspur_bin_,
+                "-d", port_,
+                "--admask", ad_mask,
+                "--msq-key", std::to_string(key_)};
         if (digital_input_enable_)
           args.push_back(std::string("--enable-get-digital-io"));
         if (simulate_)
@@ -706,8 +705,7 @@ public:
       }
       double ret;
       boost::atomic<bool> done(false);
-      auto get_vel_thread = [&ret, &done]
-      {
+      auto get_vel_thread = [&ret, &done] {
         double test_v, test_w;
         ret = YP::YPSpur_get_vel(&test_v, &test_w);
         done = true;
@@ -877,11 +875,13 @@ public:
           odom_trans.transform.translation.z = 0;
           odom_trans.transform.rotation = odom.pose.pose.orientation;
           tf_broadcaster_.sendTransform(odom_trans);
+          ROS_INFO("Odometry publsihed. Current: %f, Previous: %f",
+                   current_stamp.toSec(), prevous_odom_stamp_.toSec());
         }
         else
         {
-          ROS_WARN_THROTTLE(1.0, "Odometry timestamp skew detected. Current: %f, Previous: %f",
-                            current_stamp.toSec(), prevous_odom_stamp_.toSec());
+          ROS_WARN("Odometry timestamp skew detected. Current: %f, Previous: %f",
+                   current_stamp.toSec(), prevous_odom_stamp_.toSec());
         }
         prevous_odom_stamp_ = current_stamp;
 
@@ -1087,8 +1087,7 @@ public:
 
               auto vf = [](const double& st, const double& en,
                            const double& acc, const double& err, const double& t,
-                           const int& sig, const int& sol, double& ret)
-              {
+                           const int& sig, const int& sol, double& ret) {
                 double sq;
                 sq = -4.0 * st * st +
                      8.0 * st * en -


### PR DESCRIPTION
When `avoid_publishing_duplicated_odom_` flag is true, duplicated odometry outputs are removed.
In addition, `avoid_publishing_duplicated_odom_` flag is added. When it is true, `ypspur_ros` does not publish tf between `odom` and `base_link`.
This PR does not change the default behaviors of `ypspur_ros`.