### PR TITLE
Add option to wait convergence of joint trajectory angle and velocity

### DIFF
--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -97,6 +97,7 @@ private:
   std::map<std::string, double> params_;
   int key_;
   bool simulate_;
+  bool wait_convergence_of_joint_trajectory_angle_vel_;
 
   double tf_time_offset_;
 
@@ -451,6 +452,8 @@ public:
       ROS_WARN("simulate_control parameter is deprecated. Use simulate parameter instead");
       simulate_ = true;
     }
+    pnh_.param(
+        "wait_convergence_of_joint_trajectory_angle_vel", wait_convergence_of_joint_trajectory_angle_vel_, true);
     pnh_.param("ypspur_bin", ypspur_bin_, std::string("ypspur-coordinator"));
     pnh_.param("param_file", param_file_, std::string(""));
     pnh_.param("tf_time_offset", tf_time_offset_, 0.0);
@@ -1099,7 +1102,8 @@ public:
 
           if (done)
           {
-            if ((joints_[jid].vel_end_ > 0.0 &&
+            if (!wait_convergence_of_joint_trajectory_angle_vel_ ||
+                (joints_[jid].vel_end_ > 0.0 &&
                  joints_[jid].angle_ref_ > joint.position[jid] &&
                  joints_[jid].angle_ref_ < joint.position[jid] + joints_[jid].vel_ref_ * dt) ||
                 (joints_[jid].vel_end_ < 0.0 &&
@@ -1108,6 +1112,7 @@ public:
             {
               joints_[jid].control_ = JointParams::VELOCITY;
               joints_[jid].vel_ref_ = joints_[jid].vel_end_;
+              YP::YP_joint_vel(joints_[jid].id_, joints_[jid].vel_ref_);
             }
           }
         }

--- a/test/test/joint_trajectory.test
+++ b/test/test/joint_trajectory.test
@@ -8,5 +8,6 @@
     <param name="param_file" value="$(find ypspur_ros)/test/config/test.param" />
     <param name="joint0_enable" value="true" />
     <param name="hz" value="20.0" />
+    <param name="wait_convergence_of_joint_trajectory_angle_vel" value="false" />
   </node>
 </launch>


### PR DESCRIPTION
When controlling in joint trajectory mode, sometimes the joint's angle and velocity don't converge in the specified range after the duration (`time_from_start`). If the joint overshoots the target position in the trajectory, the joint rotates backward, but in some use cases, this behavior is not desirable. 

By this PR, `wait_convergence_of_joint_trajectory_angle_vel_` parameter is added. If this parameter is `false`, the control mode transitions to velocity mode without checking the convergence after the duration of `time_from_start`. If the parameter is `true`, the behavior is the same as before.