### PR TITLE
Update required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.0.2...3.28)
 project(ypspur_ros)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.28)
+cmake_minimum_required(VERSION 3.0.2...3.26)
 project(ypspur_ros)
 
 find_package(catkin REQUIRED COMPONENTS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0.2...3.26)
+cmake_minimum_required(VERSION 3.0...3.26)
 project(ypspur_ros)
 
 find_package(catkin REQUIRED COMPONENTS


### PR DESCRIPTION
Allow to use cmake compatibility mode up to 3.26 to avoid error/warning on the latest cmake.
CMake 4.0 dropped 3.5 and marked 3.10 as deprecated.