### PR TITLE
Initialize publish_odometry_next_ to fix odometry init timeout

### DIFF
--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -109,7 +109,7 @@ private:
   std::shared_ptr<std::thread> thread_coordinator_;
   std::atomic_bool coordinator_exited_;
   std::atomic_int coordinator_exit_code_;
-  std::atomic_bool publish_odometry_next_;
+  std::atomic_bool publish_odometry_next_{true};
 
   enum OdometryMode
   {


### PR DESCRIPTION
`publish_odometry_next_` is read in the odometry hook during init (before the main loop first sets it), but was left uninitialized.
Since std::atomic is not value-initialized before C++20, its indeterminate value could be false, so init never updates `previous_odom_stamp_` and always times out with "ypspur-coordinator is not outputting data".
Latent until the toolchain change (Alpine 3.20/GCC13 → 3.23/GCC15) flipped the value to false; fixed by defaulting it to `true`.
