### PR TITLE
Add diagnostics error on joint index signal loss

### DIFF
--- a/doc/ypspur_ros.md
+++ b/doc/ypspur_ros.md
@@ -109,6 +109,18 @@ Frequency to publish odometry data.
 
 ### ~/joint?_name [string: "joint" + i]
 
+### ~/joint?_index_check_enable [bool: false]
+
+Enable monitoring of the joint index signal.
+The diagnostic status is set to ERROR if the index signal is not detected
+while the joint travels more than `~/joint?_index_check_travel`.
+
+### ~/joint?_index_check_travel [float: 2π × 1.2]
+
+Joint travel [rad] allowed without detecting the index signal.
+The default assumes one index signal per revolution with 20% margin.
+Set explicitly if `INDEX_GEAR` is not 1.0.
+
 ### ~/vel [float: max velocity specified in the parameter file]
 
 ### ~/acc [float: max acceleration specified in the parameter file]

--- a/include/ypspur_ros/joint_index_monitor.h
+++ b/include/ypspur_ros/joint_index_monitor.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2026, the ypspur_ros authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef YPSPUR_ROS_JOINT_INDEX_MONITOR_H
+#define YPSPUR_ROS_JOINT_INDEX_MONITOR_H
+
+#include <cmath>
+
+namespace ypspur_ros
+{
+// Detects loss of the joint index signal by checking that the index signal
+// is observed at least once while the joint travels the given angle.
+class JointIndexMonitor
+{
+public:
+  explicit JointIndexMonitor(const double travel_threshold = 0)
+    : travel_threshold_(travel_threshold)
+    , initialized_(false)
+    , error_(false)
+    , wang_time_last_(0)
+    , ref_angle_(0)
+  {
+  }
+
+  void update(const double wang, const double wang_time)
+  {
+    if (!initialized_)
+    {
+      wang_time_last_ = wang_time;
+      ref_angle_ = wang;
+      initialized_ = true;
+      return;
+    }
+    if (wang_time != wang_time_last_)
+    {
+      wang_time_last_ = wang_time;
+      ref_angle_ = wang;
+      error_ = false;
+      return;
+    }
+    if (std::abs(wang - ref_angle_) > travel_threshold_)
+    {
+      error_ = true;
+    }
+  }
+
+  bool hasError() const
+  {
+    return error_;
+  }
+
+private:
+  double travel_threshold_;
+  bool initialized_;
+  bool error_;
+  double wang_time_last_;
+  double ref_angle_;
+};
+}  // namespace ypspur_ros
+
+#endif  // YPSPUR_ROS_JOINT_INDEX_MONITOR_H

--- a/include/ypspur_ros/joint_index_monitor.h
+++ b/include/ypspur_ros/joint_index_monitor.h
@@ -31,6 +31,7 @@
 #define YPSPUR_ROS_JOINT_INDEX_MONITOR_H
 
 #include <cmath>
+#include <limits>
 
 namespace ypspur_ros
 {
@@ -39,7 +40,8 @@ namespace ypspur_ros
 class JointIndexMonitor
 {
 public:
-  explicit JointIndexMonitor(const double travel_threshold = 0)
+  explicit JointIndexMonitor(
+      const double travel_threshold = std::numeric_limits<double>::infinity())
     : travel_threshold_(travel_threshold)
     , initialized_(false)
     , error_(false)

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -140,7 +140,6 @@ private:
     };
     control_mode_ control_;
     trajectory_msgs::JointTrajectory cmd_joint_;
-    bool index_check_enable_;
     ypspur_ros::JointIndexMonitor index_monitor_;
   };
   std::vector<JointParams> joints_;
@@ -400,7 +399,7 @@ private:
     std::string joint_index_error;
     for (const JointParams& j : joints_)
     {
-      if (j.index_check_enable_ && j.index_monitor_.hasError())
+      if (j.index_monitor_.hasError())
       {
         joint_index_error += (joint_index_error.empty() ? "" : ",") + j.name_;
       }
@@ -501,10 +500,7 @@ private:
 
     for (JointParams& j : joints_)
     {
-      if (j.index_check_enable_)
-      {
-        j.index_monitor_.update(odom->wang[j.id_], odom->wang_time[j.id_]);
-      }
+      j.index_monitor_.update(odom->wang[j.id_], odom->wang_time[j.id_]);
     }
 
     // Limit publishing rate by hz parameter
@@ -1014,8 +1010,9 @@ public:
           jp.id_ = i;
           pnh_.param(name + std::string("_name"), jp.name_, name);
           pnh_.param(name + std::string("_accel"), jp.accel_, 3.14);
-          pnh_.param(name + std::string("_index_check_enable"), jp.index_check_enable_, false);
-          if (jp.index_check_enable_)
+          bool index_check_enable;
+          pnh_.param(name + std::string("_index_check_enable"), index_check_enable, false);
+          if (index_check_enable)
           {
             double travel;
             pnh_.param(

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -61,6 +61,7 @@
 #include <boost/thread/future.hpp>
 
 #include <atomic>
+#include <cmath>
 #include <exception>
 #include <map>
 #include <memory>

--- a/src/ypspur_ros.cpp
+++ b/src/ypspur_ros.cpp
@@ -71,6 +71,7 @@
 
 #include <compatibility.h>
 #include <ypspur_ros/direct_ypspur.h>
+#include <ypspur_ros/joint_index_monitor.h>
 
 namespace YP
 {
@@ -82,6 +83,8 @@ void sigintHandler(int sig)
 {
   g_shutdown = true;
 }
+
+constexpr double DEFAULT_INDEX_CHECK_TRAVEL_MARGIN = 1.2;
 
 class YpspurRosNode
 {
@@ -136,6 +139,8 @@ private:
     };
     control_mode_ control_;
     trajectory_msgs::JointTrajectory cmd_joint_;
+    bool index_check_enable_;
+    ypspur_ros::JointIndexMonitor index_monitor_;
   };
   std::vector<JointParams> joints_;
   std::map<std::string, int> joint_name_to_num_;
@@ -172,6 +177,7 @@ private:
   int device_error_state_prev_;
   ros::Time device_error_state_time_;
   ros::Time last_diag_update_time_;
+  std::string joint_index_error_prev_;
 
   geometry_msgs::Twist::ConstPtr cmd_vel_;
   ros::Time cmd_vel_time_;
@@ -390,17 +396,28 @@ private:
     const int connection_error =
         coordinator_exited_.load() ? coordinator_exit_code_.load() : 0;
 
+    std::string joint_index_error;
+    for (const JointParams& j : joints_)
+    {
+      if (j.index_check_enable_ && j.index_monitor_.hasError())
+      {
+        joint_index_error += (joint_index_error.empty() ? "" : ",") + j.name_;
+      }
+    }
+
     if (last_diag_update_time_ + ros::Duration(1.0) < now || connection_down ||
-        device_error_state_ != device_error_state_prev_)
+        device_error_state_ != device_error_state_prev_ ||
+        joint_index_error != joint_index_error_prev_)
     {
       device_error_state_prev_ = device_error_state_;
+      joint_index_error_prev_ = joint_index_error;
 
       diagnostic_msgs::DiagnosticArray msg;
       msg.header.stamp = now;
       msg.status.resize(1);
       msg.status[0].name = "YP-Spur Motor Controller";
       msg.status[0].hardware_id = "ipc-key" + std::to_string(key_);
-      if (device_error_state_ == 0 && connection_error == 0)
+      if (device_error_state_ == 0 && connection_error == 0 && joint_index_error.empty())
       {
         if (device_error_state_time_.isZero())
         {
@@ -431,12 +448,19 @@ private:
               std::string((msg.status[0].message.size() > 0 ? " " : "")) +
               "Motor controller reported error id " +
               std::to_string(device_error_state_) + ".";
+        if (!joint_index_error.empty())
+          msg.status[0].message +=
+              std::string((msg.status[0].message.size() > 0 ? " " : "")) +
+              "Joint index signal is not detected within expected rotation: " +
+              joint_index_error + ".";
       }
-      msg.status[0].values.resize(2);
+      msg.status[0].values.resize(3);
       msg.status[0].values[0].key = "connection_error";
       msg.status[0].values[0].value = std::to_string(connection_error);
       msg.status[0].values[1].key = "device_error";
       msg.status[0].values[1].value = std::to_string(device_error_state_);
+      msg.status[0].values[2].key = "joint_index_signal_error";
+      msg.status[0].values[2].value = joint_index_error;
 
       pubs_["diag"].publish(msg);
       last_diag_update_time_ = now;
@@ -472,6 +496,14 @@ private:
         }
       }
       device_error_state_time_ = ros::Time(latest_err_time);
+    }
+
+    for (JointParams& j : joints_)
+    {
+      if (j.index_check_enable_)
+      {
+        j.index_monitor_.update(odom->wang[j.id_], odom->wang_time[j.id_]);
+      }
     }
 
     // Limit publishing rate by hz parameter
@@ -981,6 +1013,15 @@ public:
           jp.id_ = i;
           pnh_.param(name + std::string("_name"), jp.name_, name);
           pnh_.param(name + std::string("_accel"), jp.accel_, 3.14);
+          pnh_.param(name + std::string("_index_check_enable"), jp.index_check_enable_, false);
+          if (jp.index_check_enable_)
+          {
+            double travel;
+            pnh_.param(
+                name + std::string("_index_check_travel"), travel,
+                2.0 * M_PI * DEFAULT_INDEX_CHECK_TRAVEL_MARGIN);
+            jp.index_monitor_ = ypspur_ros::JointIndexMonitor(travel);
+          }
           joint_name_to_num_[jp.name_] = num;
           joints_.push_back(jp);
           // printf("%s %d %d", jp.name_.c_str(), jp.id_, joint_name_to_num_[jp.name_]);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,11 @@
 find_package(rostest REQUIRED)
 
+catkin_add_gtest(test_joint_index_monitor src/joint_index_monitor.cpp)
+
+add_rostest_gtest(test_joint_index_check test/joint_index_check.test
+    src/joint_index_check.cpp)
+target_link_libraries(test_joint_index_check ${catkin_LIBRARIES})
+
 add_rostest_gtest(test_joint_trajectory test/joint_trajectory.test
     src/joint_trajectory.cpp)
 target_link_libraries(test_joint_trajectory ${catkin_LIBRARIES})

--- a/test/src/joint_index_check.cpp
+++ b/test/src/joint_index_check.cpp
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2026, the ypspur_ros authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <string>
+
+#include <ros/ros.h>
+
+#include <diagnostic_msgs/DiagnosticArray.h>
+#include <sensor_msgs/JointState.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+#include <gtest/gtest.h>
+
+TEST(JointIndexCheck, ErrorOnIndexSignalLoss)
+{
+  ros::WallDuration wait(0.05);
+
+  ros::NodeHandle nh;
+  ros::Publisher pub_cmd =
+      nh.advertise<trajectory_msgs::JointTrajectory>("joint_trajectory", 1, true);
+
+  sensor_msgs::JointState::ConstPtr joint_states;
+  const boost::function<void(const sensor_msgs::JointState::ConstPtr&)> cb_joint =
+      [&joint_states](const sensor_msgs::JointState::ConstPtr& msg) -> void
+  {
+    joint_states = msg;
+  };
+  ros::Subscriber sub_joint_states =
+      nh.subscribe("joint_states", 100, cb_joint);
+
+  diagnostic_msgs::DiagnosticStatus::Ptr diag;
+  const boost::function<void(const diagnostic_msgs::DiagnosticArray::ConstPtr&)> cb_diag =
+      [&diag](const diagnostic_msgs::DiagnosticArray::ConstPtr& msg) -> void
+  {
+    for (const diagnostic_msgs::DiagnosticStatus& status : msg->status)
+    {
+      if (status.name == "YP-Spur Motor Controller")
+      {
+        diag.reset(new diagnostic_msgs::DiagnosticStatus(status));
+      }
+    }
+  };
+  ros::Subscriber sub_diag =
+      nh.subscribe("/diagnostics", 100, cb_diag);
+
+  // Wait until ypspur_ros
+  for (int i = 0; i < 20 * 30; ++i)
+  {
+    wait.sleep();
+    ros::spinOnce();
+    if (joint_states && diag)
+      break;
+  }
+  ASSERT_TRUE(static_cast<bool>(joint_states));
+  ASSERT_TRUE(static_cast<bool>(diag));
+
+  // Index signal error must not be reported while the joint is stopped
+  for (int i = 0; i < 40; ++i)
+  {
+    wait.sleep();
+    ros::spinOnce();
+    ASSERT_NE(diag->level, diagnostic_msgs::DiagnosticStatus::ERROR)
+        << "Index signal error must not be reported while stopped: "
+        << diag->message;
+  }
+
+  // Rotate the joint continuously
+  // (the joint keeps vel_end_ after the trajectory)
+  trajectory_msgs::JointTrajectory cmd;
+  cmd.header.stamp = ros::Time::now();
+  cmd.joint_names.resize(1);
+  cmd.joint_names[0] = "joint0";
+  cmd.points.resize(1);
+  cmd.points[0].time_from_start = ros::Duration(1);
+  cmd.points[0].positions.resize(1);
+  cmd.points[0].positions[0] = 2.0;
+  cmd.points[0].velocities.resize(1);
+  cmd.points[0].velocities[0] = 2.0;
+  pub_cmd.publish(cmd);
+
+  // joint0_index_check_travel is expected to be exceeded in about 2 seconds
+  bool error_detected = false;
+  for (int i = 0; i < 20 * 10; ++i)
+  {
+    wait.sleep();
+    ros::spinOnce();
+    if (diag->level == diagnostic_msgs::DiagnosticStatus::ERROR)
+    {
+      error_detected = true;
+      break;
+    }
+  }
+  ASSERT_TRUE(error_detected)
+      << "Index signal loss must be reported as diagnostic error";
+  ASSERT_NE(diag->message.find("Joint index signal is not detected"), std::string::npos)
+      << "Unexpected message: " << diag->message;
+
+  bool key_found = false;
+  for (const diagnostic_msgs::KeyValue& value : diag->values)
+  {
+    if (value.key == "joint_index_signal_error")
+    {
+      key_found = true;
+      ASSERT_EQ(value.value, "joint0");
+    }
+  }
+  ASSERT_TRUE(key_found);
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  ros::init(argc, argv, "test_joint_index_check");
+
+  return RUN_ALL_TESTS();
+}

--- a/test/src/joint_index_monitor.cpp
+++ b/test/src/joint_index_monitor.cpp
@@ -36,6 +36,18 @@ namespace
 constexpr double kThreshold = 6.4;
 }  // namespace
 
+TEST(JointIndexMonitor, NeverErrorWhenDefaultConstructed)
+{
+  ypspur_ros::JointIndexMonitor monitor;
+  double wang = 0;
+  for (int i = 0; i < 1000; ++i)
+  {
+    wang += 1.0;
+    monitor.update(wang, 0);
+    ASSERT_FALSE(monitor.hasError()) << "wang: " << wang;
+  }
+}
+
 TEST(JointIndexMonitor, NoErrorWhileStopped)
 {
   ypspur_ros::JointIndexMonitor monitor(kThreshold);

--- a/test/src/joint_index_monitor.cpp
+++ b/test/src/joint_index_monitor.cpp
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2026, the ypspur_ros authors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the copyright holder nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ypspur_ros/joint_index_monitor.h>
+
+#include <gtest/gtest.h>
+
+namespace
+{
+constexpr double kThreshold = 6.4;
+}  // namespace
+
+TEST(JointIndexMonitor, NoErrorWhileStopped)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  for (int i = 0; i < 100; ++i)
+  {
+    monitor.update(1.0, 0);
+    ASSERT_FALSE(monitor.hasError());
+  }
+}
+
+TEST(JointIndexMonitor, FirstSampleBecomesReference)
+{
+  // Non-zero initial wang_time must be treated as the reference, not as an
+  // index signal
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  monitor.update(10.0, 123.4);
+  ASSERT_FALSE(monitor.hasError());
+  monitor.update(10.0 + kThreshold + 0.1, 123.4);
+  ASSERT_TRUE(monitor.hasError());
+}
+
+TEST(JointIndexMonitor, ErrorOnForwardTravelWithoutIndex)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  double wang = 0;
+  while (wang < kThreshold)
+  {
+    monitor.update(wang, 0);
+    ASSERT_FALSE(monitor.hasError()) << "wang: " << wang;
+    wang += 0.1;
+  }
+  monitor.update(kThreshold + 0.1, 0);
+  ASSERT_TRUE(monitor.hasError());
+}
+
+TEST(JointIndexMonitor, ErrorOnReverseTravelWithoutIndex)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  double wang = 0;
+  while (wang > -kThreshold)
+  {
+    monitor.update(wang, 0);
+    ASSERT_FALSE(monitor.hasError()) << "wang: " << wang;
+    wang -= 0.1;
+  }
+  monitor.update(-kThreshold - 0.1, 0);
+  ASSERT_TRUE(monitor.hasError());
+}
+
+TEST(JointIndexMonitor, NoErrorOnOscillationWithinThreshold)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  for (int cycle = 0; cycle < 10; ++cycle)
+  {
+    for (double wang = 0; wang < kThreshold * 0.9; wang += 0.1)
+    {
+      monitor.update(wang, 0);
+      ASSERT_FALSE(monitor.hasError());
+    }
+    for (double wang = kThreshold * 0.9; wang > 0; wang -= 0.1)
+    {
+      monitor.update(wang, 0);
+      ASSERT_FALSE(monitor.hasError());
+    }
+  }
+}
+
+TEST(JointIndexMonitor, NoErrorWithPeriodicIndex)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  double wang = 0;
+  double wang_time = 100.0;
+  monitor.update(wang, wang_time);
+  for (int rev = 0; rev < 10; ++rev)
+  {
+    for (int i = 0; i < 63; ++i)
+    {
+      wang += 0.1;
+      monitor.update(wang, wang_time);
+      ASSERT_FALSE(monitor.hasError()) << "wang: " << wang;
+    }
+    wang_time += 6.3;
+  }
+}
+
+TEST(JointIndexMonitor, RecoverOnIndexSignal)
+{
+  ypspur_ros::JointIndexMonitor monitor(kThreshold);
+  monitor.update(0, 0);
+  monitor.update(kThreshold + 0.1, 0);
+  ASSERT_TRUE(monitor.hasError());
+
+  // Index signal resets the error and the reference angle
+  monitor.update(kThreshold + 0.2, 200.0);
+  ASSERT_FALSE(monitor.hasError());
+  monitor.update(kThreshold + 0.2 + kThreshold * 0.9, 200.0);
+  ASSERT_FALSE(monitor.hasError());
+  monitor.update(kThreshold + 0.2 + kThreshold + 0.1, 200.0);
+  ASSERT_TRUE(monitor.hasError());
+}
+
+int main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}

--- a/test/test/joint_index_check.test
+++ b/test/test/joint_index_check.test
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<launch>
+  <env name="GCOV_PREFIX" value="/tmp/gcov/ypspur_ros_joint_index_check" />
+
+  <test test-name="test_joint_index_check" pkg="ypspur_ros" type="test_joint_index_check" />
+
+  <node pkg="ypspur_ros" type="ypspur_ros" name="ypspur_ros">
+    <param name="compatible" value="1" />
+    <param name="ipc_key" value="28744" />
+    <param name="simulate" value="true" />
+    <param name="param_file" value="$(find ypspur_ros)/test/config/joint.param" />
+    <param name="joint0_enable" value="true" />
+    <param name="joint0_index_check_enable" value="true" />
+    <param name="joint0_index_check_travel" value="3.0" />
+    <param name="hz" value="20.0" />
+    <param name="wait_convergence_of_joint_trajectory_angle_vel" value="false" />
+  </node>
+</launch>


### PR DESCRIPTION
Set the diagnostic status to ERROR when the joint index signal is not detected while the joint travels more than a threshold, and clear it automatically once the index signal is detected again.
This detects hardware failures of the index signal, which leave the absolute angle of the joint undetermined.
The check is opt-in per joint via `joint{i}_index_check_enable`, with the travel threshold configurable via `joint{i}_index_check_travel` (default 2π × 1.2).
